### PR TITLE
Update default PortProxy destination IP

### DIFF
--- a/scripts/portproxy-helper/portproxy-helper.bat
+++ b/scripts/portproxy-helper/portproxy-helper.bat
@@ -10,7 +10,7 @@ title PortProxy Helper (v4tov4)
 :: -----------------------------------------------------------------
 
 :: Default destination IP used when adding new rules
-set "DEFAULT_DEST_IP=192.168.0.100"
+set "DEFAULT_DEST_IP=192.168.10.5"
 
 :: Ensure we are running with administrative privileges
 call :EnsureAdmin
@@ -78,7 +78,7 @@ set "DEST_PORT=%PORT%"
 set /p DEST_IP=Enter destination IP (remote) [default %DEFAULT_DEST_IP%]:if "%DEST_IP%"=="" set "DEST_IP=%DEFAULT_DEST_IP%"
 call :CHECK_IP "%DEST_IP%"
 if errorlevel 1 (
-    echo [!] Invalid IPv4 format. Example: 192.168.0.100
+    echo [!] Invalid IPv4 format. Example: 192.168.10.5
     pause
     goto Menu
 )


### PR DESCRIPTION
## Summary
- change default destination IP to 192.168.10.5
- update invalid IP example in error message

## Testing
- `pre-commit run --files scripts/portproxy-helper/portproxy-helper.bat` *(command not found)*
- `shellcheck scripts/portproxy-helper/portproxy-helper.bat` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bac4209828832683af40f5bfedf580