### PR TITLE
Fix default destination IP prompt in portproxy helper

### DIFF
--- a/scripts/portproxy-helper/portproxy-helper.bat
+++ b/scripts/portproxy-helper/portproxy-helper.bat
@@ -75,7 +75,8 @@ set "LISTEN_PORT=%PORT%"
 set "DEST_PORT=%PORT%"
 
 :: ask only for destination IP
-set /p DEST_IP=Enter destination IP (remote) [default %DEFAULT_DEST_IP%]:if "%DEST_IP%"=="" set "DEST_IP=%DEFAULT_DEST_IP%"
+set /p DEST_IP=Enter destination IP (remote) [default %DEFAULT_DEST_IP%]:
+if "%DEST_IP%"=="" set "DEST_IP=%DEFAULT_DEST_IP%"
 call :CHECK_IP "%DEST_IP%"
 if errorlevel 1 (
     echo [!] Invalid IPv4 format. Example: 192.168.10.5


### PR DESCRIPTION
## Summary
- prevent default DEST_IP fallback logic from printing in prompt by separating `set /p` and `if`

## Testing
- `bash scripts/portproxy-helper/portproxy-helper.bat` *(fails: `command not found`, Windows batch commands require Windows environment)*

------
https://chatgpt.com/codex/tasks/task_e_68bac7196b808326b9fac50417df3f36