### PR TITLE
Fix destination IP validation in portproxy helper

### DIFF
--- a/scripts/portproxy-helper/portproxy-helper.bat
+++ b/scripts/portproxy-helper/portproxy-helper.bat
@@ -79,7 +79,12 @@ set "DEST_PORT=%PORT%"
 :: ask only for destination IP
 set /p DEST_IP=Enter destination IP (remote) [default %DEFAULT_DEST_IP%]:
 if "%DEST_IP%"=="" set "DEST_IP=%DEFAULT_DEST_IP%"
-call :CHECK_IP "%DEST_IP%"
+
+:: normalize accidental spaces around the value
+for /f "tokens=* delims= " %%A in ("%DEST_IP%") do set "DEST_IP=%%A"
+
+:: validate IPv4 directly here to avoid label-call edge cases in some cmd environments
+echo %DEST_IP%| findstr /R "^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$" >nul
 if errorlevel 1 (
     echo [!] Invalid IPv4 format. Example: 192.168.10.5
     pause
@@ -198,7 +203,3 @@ if %VAL% lss 1  (echo [!] Port must be >= 1.& goto :ASK_PORT_LOOP)
 if %VAL% gtr 65535 (echo [!] Port must be <= 65535.& goto :ASK_PORT_LOOP)
 goto :eof
 
-:CHECK_IP
-set "IP=%~1"
-echo %IP%| findstr /R "^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$" >nul || (exit /b 1)
-exit /b 0


### PR DESCRIPTION
### Motivation
- Users could hit "The system cannot find the batch label specified - CHECK_IP" when adding/updating a rule and inputs with accidental spaces could fail validation, so validation should be robust and self-contained.

### Description
- In `scripts/portproxy-helper/portproxy-helper.bat` replace the `call :CHECK_IP` usage with inline IPv4 validation using `findstr` and normalize the entered `DEST_IP` by trimming accidental spaces, and remove the now-unused `:CHECK_IP` label.

### Testing
- Verified no remaining `CHECK_IP` references with `rg -n "CHECK_IP|Modbus|OPC UA|port 502|batch label"` and inspected the change with `git diff -- scripts/portproxy-helper/portproxy-helper.bat` to confirm the inline validation and trimming logic were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c6f200e48326a1d422616598cf65)